### PR TITLE
Add support for extra template directories

### DIFF
--- a/app/src/main/java/hello/App.java
+++ b/app/src/main/java/hello/App.java
@@ -6,6 +6,7 @@ public class App extends Site {
     public void setup() {
         var hello = get("/hello", c -> c.print(c.template("hello")));
         get("/", c -> c.redirect(hello));
+        get("/world", c -> c.print(c.template("world")));
     }
 
     public static void main(String[] args) {

--- a/app/src/main/resources/templates/world.html
+++ b/app/src/main/resources/templates/world.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><!--v title-->Hello<!--/v--></title>
+    <link rel="stylesheet" href="{{v webapp:rootUrl/}}css/style.css?{{v context:paramRandom/}}">
+</head>
+<body>
+<p>Hello World from src/main/resources/templates</p>
+</body>
+</html>

--- a/build-logic/src/test-projects/minimal/src/main/resources/templates/world.html
+++ b/build-logic/src/test-projects/minimal/src/main/resources/templates/world.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><!--v title-->Hello<!--/v--></title>
+    <link rel="stylesheet" href="{{v webapp:rootUrl/}}css/style.css?{{v context:paramRandom/}}">
+</head>
+<body>
+<p>Hello World</p>
+</body>
+</html>

--- a/build-logic/src/test/groovy/com/uwyn/rife2/gradle/PackagingTest.groovy
+++ b/build-logic/src/test/groovy/com/uwyn/rife2/gradle/PackagingTest.groovy
@@ -25,6 +25,9 @@ class PackagingTest extends AbstractFunctionalTest {
                 }
             }
             assert Files.exists(fs.getPath("/rife/template/html/hello.class"))
+            assert Files.exists(fs.getPath("/rife/template/html/world.class"))
+            assert !Files.exists(fs.getPath("/templates/hello.html"))
+            assert !Files.exists(fs.getPath("/templates/world.html"))
         }
 
         where:

--- a/build-logic/src/test/groovy/com/uwyn/rife2/gradle/TemplateCompilationTest.groovy
+++ b/build-logic/src/test/groovy/com/uwyn/rife2/gradle/TemplateCompilationTest.groovy
@@ -42,6 +42,7 @@ class TemplateCompilationTest extends AbstractFunctionalTest {
 
         then: "template sources must be present in the classpath"
         outputContains("Classpath entry: src/main/templates")
+        outputContains("Classpath entry: src/main/resources/templates")
     }
 
     def "compiles templates when running #task"() {


### PR DESCRIPTION
By default, the template was using `src/main/templates` as the source directory for templates. This has the benefit of properly isolating the templates from the application classpath: the framework is then responsible for injecting them to the app runtime in whatever suitable form: either untouched as sources (in development mode), or precompiled (for production).

With this change, it is also possible to use `src/main/resources/templates` as a source directory. It _may_ feel more natural to users (although I would disagree), but it has the drawback that the jars have to be configured to _exclude_ those resources, because by default whatever is in `src/main/resources` MUST be included in a jar (independently of the run mode).

It is also possible for the user to configure additional source directories should they want to.