### PR TITLE
Make the template directories configurable

### DIFF
--- a/build-logic/src/main/java/com/uwyn/rife2/gradle/Rife2Extension.java
+++ b/build-logic/src/main/java/com/uwyn/rife2/gradle/Rife2Extension.java
@@ -15,6 +15,7 @@
  */
 package com.uwyn.rife2.gradle;
 
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
@@ -26,4 +27,6 @@ public abstract class Rife2Extension {
     public abstract Property<String> getUberMainClass();
 
     public abstract ListProperty<TemplateType> getPrecompiledTemplateTypes();
+
+    public abstract ConfigurableFileCollection getTemplateDirectories();
 }


### PR DESCRIPTION
Adding a directory can be done via the extension:

```gradle
rife2 {
   templateDirectories.from(file("my-template-dir"))
}
```

By default the template directories include both `src/main/templates` and `src/main/resources/templates`. If you want to ignore those, then you need to clear the default:

```gradle
rife2 {
    templateDirectories.from.clear()
    templateDirectories.from(file("my-template-dir"))
}
```